### PR TITLE
device/qcom/sepolicy: fix the sepolicy [3/3]

### DIFF
--- a/common/file.te
+++ b/common/file.te
@@ -7,6 +7,9 @@ type qmuxd_socket, file_type;
 #Define the netmgrd socket type
 type netmgrd_socket, file_type;
 
+#QTI file types
+type qti_data_file, file_type, data_file_type;
+
 #Define the pps socket type
 type pps_socket, file_type;
 

--- a/common/file_contexts
+++ b/common/file_contexts
@@ -549,6 +549,7 @@
 /data/misc/radio(/.*)?                                              u:object_r:radio_data_file:s0
 /data/vendor/radio(/.*)?                                            u:object_r:vendor_radio_data_file:s0
 /data/vendor/netmgr(/.*)?                                           u:object_r:netmgrd_data_file:s0
+/data/vendor/qti(/.*)?						    u:object_r:qti_data_file:s0
 /data/vendor/port_bridge(/.*)?                                      u:object_r:port_bridge_data_file:s0
 /data/misc/fm(/.*)?                                                 u:object_r:fm_data_file:s0
 /data/misc/audio_pp(/.*)?                                           u:object_r:audio_pp_data_file:s0

--- a/common/init.te
+++ b/common/init.te
@@ -56,3 +56,5 @@ allow init rawdump_block_device:blk_file setattr;
 
 #cpu.rt_period_us and _runtime_us need this
 allow init cgroup:file create;
+
+allow init sysfs_cpu_boost:dir { write };

--- a/common/init_shell.te
+++ b/common/init_shell.te
@@ -136,8 +136,6 @@ allow qti_init_shell sysfs_msm_power:file write;
 r_dir_file(qti_init_shell, sysfs_thermal)
 r_dir_file(qti_init_shell, sysfs_type)
 allow qti_init_shell sysfs_socinfo:file write;
-allow qti_init_shell sysfs:{ dir file lnk_file } relabelfrom;
-allow qti_init_shell sysfs_devices_system_cpu: { dir file lnk_file } relabelto;
 # Check if /dev/sensors or /dev/msm_dsps present
 allow qti_init_shell sensors_data_file:dir r_dir_perms;
 allow qti_init_shell sensors_device:chr_file r_file_perms;
@@ -259,8 +257,6 @@ set_prop(qti_init_shell, mmi_prop);
 allow qti_init_shell proc_meminfo:file r_file_perms;
 
 allow qti_init_shell sysfs_msm_power:file rw_file_perms;
-allow qti_init_shell  sysfs_devices_system_cpu:dir w_file_perms;
-allow qti_init_shell  sysfs_devices_system_cpu:file rw_file_perms;
 
 allow qti_init_shell sysfs_usb_mtp_device:dir r_dir_perms;
 allow qti_init_shell sysfs_usb_mtp_device:file rw_file_perms;
@@ -268,3 +264,15 @@ allow qti_init_shell sysfs_usb_mtp_device:file rw_file_perms;
 # For IO Cgroups
 allow qti_init_shell cgroup:dir { mounton create_dir_perms };
 allow qti_init_shell cgroup:file { create_file_perms };
+
+allow qti_init_shell sysfs_cpu_boost:dir r_dir_perms;
+allow qti_init_shell sysfs_cpu_boost:file rw_file_perms;
+
+# Creating files on sysfs is impossible so this isn't a threat.
+# donotaudit dir write on any sysfs_type and procfs
+# Add a neverallow to prevent adding policy for the same
+dontaudit qti_init_shell sysfs_type:dir write;
+dontaudit qti_init_shell proc:dir write;
+
+neverallow qti_init_shell sysfs_type:dir no_w_dir_perms;
+neverallow qti_init_shell proc:dir no_w_dir_perms;

--- a/common/qti.te
+++ b/common/qti.te
@@ -25,8 +25,14 @@ allow qti { vendor_shell_exec system_file }:file rx_file_perms;
 
 allow qti sysfs_data:file r_file_perms;
 
+# Allow write permissions for log file
+allow qti qti_data_file:file create_file_perms;
+allow qti qti_data_file:dir rw_dir_perms;
+
 #diag
 userdebug_or_eng(`
     diag_use(qti)
     allow qti sysfs:file r_file_perms;
 ')
+
+allow qti shell_exec:file { read open execute execute_no_trans getattr };

--- a/common/service.te
+++ b/common/service.te
@@ -13,3 +13,5 @@ type dtseagleservice_service,     service_manager_type;
 type gba_auth_service,            service_manager_type;
 type mdtpdaemon_service,          service_manager_type;
 type qtitetherservice_service,    service_manager_type;
+type pocket_service,		  system_api_service, system_server_service, service_manager_type;
+type edgegesture_service,	  system_api_service, system_server_service, service_manager_type;

--- a/common/service_contexts
+++ b/common/service_contexts
@@ -45,3 +45,5 @@ com.qualcomm.qti.uceservice                    u:object_r:imsrcs_service:s0
 # DOLBY_START
 media.dolby_memoryservice                      u:object_r:audioserver_service:s0
 # DOLBY_END
+pocket					       u:object_r:pocket_service:s0
+edgegestureservice			       u:object_r:edgegesture_service:s0

--- a/common/system_server.te
+++ b/common/system_server.te
@@ -201,3 +201,10 @@ hal_client_domain(system_server, hal_iop)
 r_dir_file(system_server, kgsl_debugfs);
 
 allow system_server qti_debugfs:file r_file_perms;
+
+allow system_server pocket_service:service_manager { add find };
+
+allow system_server edgegesture_service:service_manager { add find };
+
+allow system_server default_android_service:service_manager { add };
+

--- a/common/usb_uicc_daemon.te
+++ b/common/usb_uicc_daemon.te
@@ -8,5 +8,5 @@ init_daemon_domain(usb_uicc_daemon)
 allow usb_uicc_daemon self:socket create_socket_perms_no_ioctl;
 allow usb_uicc_daemon usb_uicc_device:chr_file rw_file_perms;
 allow usb_uicc_daemon sysfs_usb_uicc:file rw_file_perms;
-allow usb_uicc_daemon sysfs_usb_uicc:dir rw_dir_perms;
+allow usb_uicc_daemon sysfs_usb_uicc:dir r_dir_perms;
 set_prop(usb_uicc_daemon, uicc_prop)


### PR DESCRIPTION
this commit contains the following changes:
* fix permissions for cpu_boost
* fix permissions for /system/bin/sh
* fix permissions for service=profile
* fix permissions for qti
* add pocket judge sepolicy
* add edgegesture sepolicy

and some more minor changes